### PR TITLE
Fixed nginx repo url

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -19,7 +19,7 @@ invoicePlane:
     - /srv/docker/invoiceplane/nginx/sites-enabled:/etc/nginx/sites-enabled
 
 nginx:
-  image: quay.io/sameersbn/nginx:1.8.0-5
+  image: quay.io/sameersbn/nginx:v1.8.0-5
   links:
     - invoicePlane:invoiceplane-php-fpm
   volumes_from:


### PR DESCRIPTION
Tags followed a syntax of v*.*.* while the file pointed to a version of only *.*.*