### PR TITLE
Add PROXY_IPS setting

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -4,6 +4,7 @@ source ${INVOICEPLANE_RUNTIME_DIR}/env-defaults
 
 INVOICEPLANE_TEMPLATES_DIR=${INVOICEPLANE_RUNTIME_DIR}/config
 INVOICEPLANE_CONFIG=${INVOICEPLANE_INSTALL_DIR}/index.php
+INVOICEPLANE_CODEIGNITER_CONFIG=${INVOICEPLANE_INSTALL_DIR}/application/config/config.php
 INVOICEPLANE_DATABASE_CONFIG=${INVOICEPLANE_INSTALL_DIR}/application/config/database.php
 INVOICEPLANE_NGINX_CONFIG=/etc/nginx/sites-enabled/InvoicePlane.conf
 
@@ -166,9 +167,11 @@ invoiceplane_finalize_php_fpm_parameters() {
   INVOICEPLANE_PHP_FPM_PORT=${INVOICEPLANE_PHP_FPM_PORT:-9000}
 }
 
-invoiceplane_configure_url() {
+invoiceplane_configure_settings() {
   echo "Configuring InvoicePlane::URL"
   sed -i "s|^define('IP_URL', '.*');|define('IP_URL', '"${INVOICEPLANE_URL}"');|" ${INVOICEPLANE_CONFIG}
+  echo "Configuring InvoicePlane::Proxy"
+  sed -i "s|config\['proxy_ips'\] = '';|config['proxy_ips'] = '"${PROXY_IPS}"';|" ${INVOICEPLANE_CODEIGNITER_CONFIG}
 }
 
 invoiceplane_configure_database() {
@@ -355,7 +358,7 @@ initialize_system() {
 
 configure_invoiceplane() {
   echo "Configuring InvoicePlane..."
-  invoiceplane_configure_url
+  invoiceplane_configure_settings
   invoiceplane_configure_database
   invoiceplane_configure_timezone
 }


### PR DESCRIPTION
This change allows to run invoiceplane behind a reverse proxy.

```
|--------------------------------------------------------------------------
| Reverse Proxy IPs
|--------------------------------------------------------------------------
|
| If your server is behind a reverse proxy, you must whitelist the proxy
| IP addresses from which CodeIgniter should trust headers such as
| HTTP_X_FORWARDED_FOR and HTTP_CLIENT_IP in order to properly identify
| the visitor's IP address.
|
| You can use both an array or a comma-separated list of proxy addresses,
| as well as specifying whole subnets. Here is an example:
|
| '10.0.1.200,192.168.5.0/24'
|--------------------------------------------------------------------------
```